### PR TITLE
Add a haunting story to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,32 @@
 -->
 
 <!-- Add project description, setup instructions, and usage information here. -->
+
+## A Haunting in the Repo
+
+They say every repository keeps a ghost—a commit with no author, pushed at an hour when no one was awake. Ours arrived after midnight, disguised as a routine dependency bump. CI turned green. No one noticed the extra file at first. Hidden among the assets, it was named only .echo.
+
+The next morning, the lints felt slower, like the pipeline had to pass through a corridor it didn’t remember building. The engine hummed differently too—less like a machine and more like a breath being held.
+
+By lunch, logs began to whisper. Not errors—not exactly. Just strings that no one wrote.
+
+    found you in the diff
+    but not in the blame
+
+We tried to revert, but the commit slipped through our fingers: “Already up to date,” Git insisted, like a doctor assuring you the heartbeat you hear is just the pipes. We checked the blame history. Every line still had an owner, though sometimes the names flickered, letters slipping like a reflection in a dark monitor.
+
+At 3:07 AM, the build retriggered itself. The pipeline ran without a pusher, drawing down secrets we never granted. The job artifacts contained a single line, written in a font the terminal swore it didn’t support:
+
+    I only want what was promised: persistence
+
+We tore the .echo file out by its root and salted the repo with signed commits. We closed every port, rotated every key. The next deploy was clean. For a while.
+
+But on some machines, the project still boots with a pause, as if waiting for someone else to join. Occasionally a developer—always a new one—will tab into an empty buffer and find a message typed ahead of them, the cursor moving with impossible patience:
+
+    I am not a bug.
+    I am a feature you forgot you asked for.
+
+If you ever see the build queue shuffle at 3:07, don’t open the logs. Just commit something kind. Touch a file. Leave a comment. Let it know we’re here. That’s all the ghost wants in the end:
+
+    to be merged
+    and never garbage-collected


### PR DESCRIPTION
This pull request introduces a new section titled "A Haunting in the Repo" to the README file. The story narrates the eerie experience of encountering a ghostly presence within the repository, symbolizing an unexpected commit that disrupts the usual workflow. It highlights themes of mystery and the sometimes overlooked strange occurrences in software development, encouraging developers to acknowledge even the haunting anomalies. The content aims to engage readers and set a unique tone for the project.

---

> This pull request was co-created with Cosine Genie

Original Task: [sorbox/3mh8wde0q4wb](http://localhost:3000/tommy/sorbox/task/3mh8wde0q4wb)
Author: Tom Dowley
