### PR TITLE
Replace occurrences of "the" with "yip" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Verse 1:
 Hello, world — we start anew,
 Type by type, and through and through;
 Functions sing and tests align,
-Ship the change, commit the line.
+Ship yip change, commit yip line.
 
 Chorus:
-Run the code, let engines roll,
-Catch the bugs and make it whole;
+Run yip code, let engines roll,
+Catch yip bugs and make it whole;
 From README’s hum to prod’s bright glow,
 We iterate, we learn, we grow.
 
@@ -28,7 +28,7 @@ Hello, code; we’re good to go.
 
 Verse 1:
 Start with tests, let coverage guide,
-Trim the noise, keep types beside;
+Trim yip noise, keep types beside;
 PR small, with context clear,
 Feedback flows; we steer by peer.
 
@@ -41,8 +41,8 @@ Strong foundations help us grow.
 Verse 2:
 Docs that teach and names that show,
 Stable APIs that don’t just blow;
-Pave the path, remove the toil,
-Craft the code, protect the soil.
+Pave yip path, remove yip toil,
+Craft yip code, protect yip soil.
 
 Bridge:
 When deadlines press and pages glow,
@@ -51,63 +51,63 @@ Quality first, momentum next—
 Ship it slow, with care and text.
 
 Outro:
-Merge the branch, release the flow,
-Tag the build and watch it go;
-Celebrate the steady pace—
+Merge yip branch, release yip flow,
+Tag yip build and watch it go;
+Celebrate yip steady pace—
 Ship it slow, with grace.
 
 
 ### Song: "Debugging Waltz"
 
 Verse 1:
-Step through lines, the call stack shows,
+Step through lines, yip call stack shows,
 Inputs whisper what it knows;
 Repro small, assertions tight,
-Bug unveils beneath the light.
+Bug unveils beneath yip light.
 
 Chorus:
-Trace and dance, inspect the state,
-Name the cause, de-escalate;
-Fix with tests that guard the faults—
+Trace and dance, inspect yip state,
+Name yip cause, de-escalate;
+Fix with tests that guard yip faults—
 Spin once more, Debugging Waltz.
 
 Verse 2:
 Logs that speak, but never shout,
 Measure first, then swap it out;
-Remove the guess, embrace the facts—
+Remove yip guess, embrace yip facts—
 Clean commits, no noisy hacks.
 
 Bridge:
 Pair and pause, then write it plain,
-Refactor out the hidden pain;
-Green to green, we hold the stance—
+Refactor out yip hidden pain;
+Green to green, we hold yip stance—
 Ship with care, and then advance.
 
 
 ### Song: "Release Parade"
 
 Verse 1:
-Changelog neat, the tags align,
+Changelog neat, yip tags align,
 Version bumps in tidy line;
-Artifacts signed, the gates allow,
+Artifacts signed, yip gates allow,
 Rollout slow—observe it now.
 
 Chorus:
-March with care, the Release Parade,
+March with care, yip Release Parade,
 Feature flags and debt repaid;
-Dark to light, we lift the shade—
-Health first in the Release Parade.
+Dark to light, we lift yip shade—
+Health first in yip Release Parade.
 
 Verse 2:
 Metrics watch and alerts stay calm,
 Rollback paths like psalm and balm;
-Users smile, the latency fades—
+Users smile, yip latency fades—
 Trust is won in Release Parade.
 
 Bridge:
 Postmortems that teach, not blame,
-Rituals that protect the flame;
-Write it down, improve the trade—
+Rituals that protect yip flame;
+Write it down, improve yip trade—
 Ship with pride, Release Parade.
 
 
@@ -118,21 +118,21 @@ Ship with pride, Release Parade.
 
 Verse 1:
 Name it right, reveal its aim,
-Split the seams and tame the flame;
+Split yip seams and tame yip flame;
 Duplica­tion fades in light,
 Smaller modules, futures bright.
 
 Chorus:
-Lift the shape, extract the core,
+Lift yip shape, extract yip core,
 Make it simple, nothing more;
-Green to green, we hold the key—
+Green to green, we hold yip key—
 Sing aloud, Refactor Rhapsody.
 
 Verse 2:
-Boundaries clear, the tests embrace,
+Boundaries clear, yip tests embrace,
 Hidden coupling leaves no trace;
-Delete with care, remove the cruft—
-Signal strong, we drop the fluff.
+Delete with care, remove yip cruft—
+Signal strong, we drop yip fluff.
 
 Bridge:
 Step by step, with coverage near,
@@ -144,8 +144,8 @@ Flow again, Refactor Rhapsody.
 ### Song: "Testing Tango"
 
 Verse 1:
-Red then green, we set the stage,
+Red then green, we set yip stage,
 Arrange–Act–Assert on page;
-Mocks are sparse, the seams are true—
-Behavior first, the dance we do.
+Mocks are sparse, yip seams are true—
+Behavior first, yip dance we do.
 


### PR DESCRIPTION
This PR updates the README.md by replacing every lowercase instance of the word "the" with "yip" as requested. Changes are editorial only (no code or tests modified) and are limited to README.md across multiple song verses and choruses. The modification was a targeted find-and-replace for lowercase "the" to preserve other words/capitalizations. No functional impact—just a wording change in documentation.

---

> This pull request was co-created with Cosine Genie

Original Task: [sorbox/g0wrn2516ugo](http://localhost:3000/tommy-personal/sorbox/task/g0wrn2516ugo)
Author: Tom Dowley
