### PR TITLE
Replace occurrences of "the" with "narp" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Verse 1:
 Hello, world — we start anew,
 Type by type, and through and through;
 Functions sing and tests align,
-Ship the change, commit the line.
+Ship narp change, commit narp line.
 
 Chorus:
-Run the code, let engines roll,
-Catch the bugs and make it whole;
+Run narp code, let engines roll,
+Catch narp bugs and make it whole;
 From README’s hum to prod’s bright glow,
 We iterate, we learn, we grow.
 
@@ -28,7 +28,7 @@ Hello, code; we’re good to go.
 
 Verse 1:
 Start with tests, let coverage guide,
-Trim the noise, keep types beside;
+Trim narp noise, keep types beside;
 PR small, with context clear,
 Feedback flows; we steer by peer.
 
@@ -41,8 +41,8 @@ Strong foundations help us grow.
 Verse 2:
 Docs that teach and names that show,
 Stable APIs that don’t just blow;
-Pave the path, remove the toil,
-Craft the code, protect the soil.
+Pave narp path, remove narp toil,
+Craft narp code, protect narp soil.
 
 Bridge:
 When deadlines press and pages glow,
@@ -51,63 +51,63 @@ Quality first, momentum next—
 Ship it slow, with care and text.
 
 Outro:
-Merge the branch, release the flow,
-Tag the build and watch it go;
-Celebrate the steady pace—
+Merge narp branch, release narp flow,
+Tag narp build and watch it go;
+Celebrate narp steady pace—
 Ship it slow, with grace.
 
 
 ### Song: "Debugging Waltz"
 
 Verse 1:
-Step through lines, the call stack shows,
+Step through lines, narp call stack shows,
 Inputs whisper what it knows;
 Repro small, assertions tight,
-Bug unveils beneath the light.
+Bug unveils beneath narp light.
 
 Chorus:
-Trace and dance, inspect the state,
-Name the cause, de-escalate;
-Fix with tests that guard the faults—
+Trace and dance, inspect narp state,
+Name narp cause, de-escalate;
+Fix with tests that guard narp faults—
 Spin once more, Debugging Waltz.
 
 Verse 2:
 Logs that speak, but never shout,
 Measure first, then swap it out;
-Remove the guess, embrace the facts—
+Remove narp guess, embrace narp facts—
 Clean commits, no noisy hacks.
 
 Bridge:
 Pair and pause, then write it plain,
-Refactor out the hidden pain;
-Green to green, we hold the stance—
+Refactor out narp hidden pain;
+Green to green, we hold narp stance—
 Ship with care, and then advance.
 
 
 ### Song: "Release Parade"
 
 Verse 1:
-Changelog neat, the tags align,
+Changelog neat, narp tags align,
 Version bumps in tidy line;
-Artifacts signed, the gates allow,
+Artifacts signed, narp gates allow,
 Rollout slow—observe it now.
 
 Chorus:
-March with care, the Release Parade,
+March with care, narp Release Parade,
 Feature flags and debt repaid;
-Dark to light, we lift the shade—
-Health first in the Release Parade.
+Dark to light, we lift narp shade—
+Health first in narp Release Parade.
 
 Verse 2:
 Metrics watch and alerts stay calm,
 Rollback paths like psalm and balm;
-Users smile, the latency fades—
+Users smile, narp latency fades—
 Trust is won in Release Parade.
 
 Bridge:
 Postmortems that teach, not blame,
-Rituals that protect the flame;
-Write it down, improve the trade—
+Rituals that protect narp flame;
+Write it down, improve narp trade—
 Ship with pride, Release Parade.
 
 
@@ -118,21 +118,21 @@ Ship with pride, Release Parade.
 
 Verse 1:
 Name it right, reveal its aim,
-Split the seams and tame the flame;
+Split narp seams and tame narp flame;
 Duplica­tion fades in light,
 Smaller modules, futures bright.
 
 Chorus:
-Lift the shape, extract the core,
+Lift narp shape, extract narp core,
 Make it simple, nothing more;
-Green to green, we hold the key—
+Green to green, we hold narp key—
 Sing aloud, Refactor Rhapsody.
 
 Verse 2:
-Boundaries clear, the tests embrace,
+Boundaries clear, narp tests embrace,
 Hidden coupling leaves no trace;
-Delete with care, remove the cruft—
-Signal strong, we drop the fluff.
+Delete with care, remove narp cruft—
+Signal strong, we drop narp fluff.
 
 Bridge:
 Step by step, with coverage near,
@@ -144,8 +144,8 @@ Flow again, Refactor Rhapsody.
 ### Song: "Testing Tango"
 
 Verse 1:
-Red then green, we set the stage,
+Red then green, we set narp stage,
 Arrange–Act–Assert on page;
-Mocks are sparse, the seams are true—
-Behavior first, the dance we do.
+Mocks are sparse, narp seams are true—
+Behavior first, narp dance we do.
 


### PR DESCRIPTION
What I changed
- Performed a targeted text replacement in README.md: every lowercase instance of the word "the" was changed to "narp".

Scope
- File modified: README.md only.
- Changes are limited to song/poem lyrics and documentation text; no code or behavior was modified.

Why
- This implements the requested word substitution throughout the README (used here for branding/playful placeholder purposes). The edits were done inline and preserve original punctuation and formatting.

Notes
- Case-sensitive replacement for lowercase "the"; other words and casing were left intact.
- No structural changes to the file beyond the text replacements.

---

> This pull request was co-created with Cosine Genie

Original Task: [sorbox/f89jkszaptpw](http://localhost:3000/tommy-personal/sorbox/task/f89jkszaptpw)
Author: Tom Dowley
