### PR TITLE
Add quick programmer joke to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,9 @@ Arrange–Act–Assert on page;
 Mocks are sparse, the seams are true—
 Behavior first, the dance we do.
 
+
+### Quick Joke
+
+Why do programmers prefer dark mode?
+Because light attracts bugs.
+


### PR DESCRIPTION
Add a short "Quick Joke" section to README.md. This change appends a programmer joke («Why do programmers prefer dark mode? Because light attracts bugs.») near the end of the file to add a bit of levity to the documentation.

---

> This pull request was co-created with Cosine Genie

Original Task: [sorbox/y1skuiushexe](http://localhost:3000/tommy/sorbox/task/y1skuiushexe)
Author: Tom Dowley
