### PR TITLE
Add 'It Works on My Machine' roast to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,8 @@ Arrange–Act–Assert on page;
 Mocks are sparse, the seams are true—
 Behavior first, the dance we do.
 
+
+### Roast: "It Works on My Machine"
+
+If your deploy guide is just "npm install && npm start" but your app needs Redis, Postgres, three feature flags, and a blood moon eclipse, it doesn't "just work"—it hostage-negotiates. Write the prerequisites. List the env vars. Automate the setup. Future-you will thank present-you for not being a chaos gremlin.
+


### PR DESCRIPTION
Adds a short "Roast: 'It Works on My Machine'" subsection to README.md. The new paragraph playfully calls out vague deploy instructions and reminds readers to list prerequisites, environment variables, and automate setup so future-you won't be stuck. Documentation-only change; no code or behavior modifications.

---

> This pull request was co-created with Cosine Genie

Original Task: [sorbox/7hmjr7esiged](http://localhost:3000/tommy/sorbox/task/7hmjr7esiged)
Author: Tom Dowley
