### PR TITLE
Replace every occurrence of 'the' with 'john' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Verse 1:
 Hello, world — we start anew,
 Type by type, and through and through;
 Functions sing and tests align,
-Ship the change, commit the line.
+Ship john change, commit john line.
 
 Chorus:
-Run the code, let engines roll,
-Catch the bugs and make it whole;
+Run john code, let engines roll,
+Catch john bugs and make it whole;
 From README’s hum to prod’s bright glow,
 We iterate, we learn, we grow.
 
@@ -28,7 +28,7 @@ Hello, code; we’re good to go.
 
 Verse 1:
 Start with tests, let coverage guide,
-Trim the noise, keep types beside;
+Trim john noise, keep types beside;
 PR small, with context clear,
 Feedback flows; we steer by peer.
 
@@ -41,8 +41,8 @@ Strong foundations help us grow.
 Verse 2:
 Docs that teach and names that show,
 Stable APIs that don’t just blow;
-Pave the path, remove the toil,
-Craft the code, protect the soil.
+Pave john path, remove john toil,
+Craft john code, protect john soil.
 
 Bridge:
 When deadlines press and pages glow,
@@ -51,63 +51,63 @@ Quality first, momentum next—
 Ship it slow, with care and text.
 
 Outro:
-Merge the branch, release the flow,
-Tag the build and watch it go;
-Celebrate the steady pace—
+Merge john branch, release john flow,
+Tag john build and watch it go;
+Celebrate john steady pace—
 Ship it slow, with grace.
 
 
 ### Song: "Debugging Waltz"
 
 Verse 1:
-Step through lines, the call stack shows,
+Step through lines, john call stack shows,
 Inputs whisper what it knows;
 Repro small, assertions tight,
-Bug unveils beneath the light.
+Bug unveils beneath john light.
 
 Chorus:
-Trace and dance, inspect the state,
-Name the cause, de-escalate;
-Fix with tests that guard the faults—
+Trace and dance, inspect john state,
+Name john cause, de-escalate;
+Fix with tests that guard john faults—
 Spin once more, Debugging Waltz.
 
 Verse 2:
 Logs that speak, but never shout,
 Measure first, then swap it out;
-Remove the guess, embrace the facts—
+Remove john guess, embrace john facts—
 Clean commits, no noisy hacks.
 
 Bridge:
 Pair and pause, then write it plain,
-Refactor out the hidden pain;
-Green to green, we hold the stance—
+Refactor out john hidden pain;
+Green to green, we hold john stance—
 Ship with care, and then advance.
 
 
 ### Song: "Release Parade"
 
 Verse 1:
-Changelog neat, the tags align,
+Changelog neat, john tags align,
 Version bumps in tidy line;
-Artifacts signed, the gates allow,
+Artifacts signed, john gates allow,
 Rollout slow—observe it now.
 
 Chorus:
-March with care, the Release Parade,
+March with care, john Release Parade,
 Feature flags and debt repaid;
-Dark to light, we lift the shade—
-Health first in the Release Parade.
+Dark to light, we lift john shade—
+Health first in john Release Parade.
 
 Verse 2:
 Metrics watch and alerts stay calm,
 Rollback paths like psalm and balm;
-Users smile, the latency fades—
+Users smile, john latency fades—
 Trust is won in Release Parade.
 
 Bridge:
 Postmortems that teach, not blame,
-Rituals that protect the flame;
-Write it down, improve the trade—
+Rituals that protect john flame;
+Write it down, improve john trade—
 Ship with pride, Release Parade.
 
 
@@ -118,21 +118,21 @@ Ship with pride, Release Parade.
 
 Verse 1:
 Name it right, reveal its aim,
-Split the seams and tame the flame;
+Split john seams and tame john flame;
 Duplica­tion fades in light,
 Smaller modules, futures bright.
 
 Chorus:
-Lift the shape, extract the core,
+Lift john shape, extract john core,
 Make it simple, nothing more;
-Green to green, we hold the key—
+Green to green, we hold john key—
 Sing aloud, Refactor Rhapsody.
 
 Verse 2:
-Boundaries clear, the tests embrace,
+Boundaries clear, john tests embrace,
 Hidden coupling leaves no trace;
-Delete with care, remove the cruft—
-Signal strong, we drop the fluff.
+Delete with care, remove john cruft—
+Signal strong, we drop john fluff.
 
 Bridge:
 Step by step, with coverage near,
@@ -144,8 +144,8 @@ Flow again, Refactor Rhapsody.
 ### Song: "Testing Tango"
 
 Verse 1:
-Red then green, we set the stage,
+Red then green, we set john stage,
 Arrange–Act–Assert on page;
-Mocks are sparse, the seams are true—
-Behavior first, the dance we do.
+Mocks are sparse, john seams are true—
+Behavior first, john dance we do.
 


### PR DESCRIPTION
What I changed:
- Updated README.md to replace every instance of the word "the" with "john" across the document.

Files modified:
- README.md

Summary:
- Per the task, all occurrences of the word "the" were replaced with "john" in the song lyrics and other prose sections. Examples include:
  - "Ship the change" -> "Ship john change"
  - "Run the code" -> "Run john code"
  - "Step through lines, the call stack shows" -> "Step through lines, john call stack shows"

Notes:
- This is a documentation-only change; no source code or tests were modified.
- The replacements may affect grammar and reading flow in the README, which is expected given the requested global substitution.

---

> This pull request was co-created with Cosine Genie

Original Task: [sorbox/3yq4pha0czmz](http://localhost:3000/tommy-personal/sorbox/task/3yq4pha0czmz)
Author: Tom Dowley
