### PR TITLE
feat: Add README joke to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,8 @@ Sing commit by commit, line by line,
 Keep the diff small, crisp, and fine,
 From TODOs to done, we cross the sea,
 With types as sails and bugs set free.
+
+Another README Joke
+
+Why did the README refuse to load? It kept getting buffered — turns out it needed to clear its cache and commit to being readable.
 hi


### PR DESCRIPTION
Adds a playful README joke to README.md. Inserts a new section labeled 'Another README Joke' with the joke: 'Why did the README refuse to load? It kept getting buffered — turns out it needed to clear its cache and commit to being readable.' The changes follow an existing poem stanza and are intended as a lighthearted touch without affecting functionality. No code changes or tests; just an updated documentation file to brighten the contribution experience.