### PR TITLE
chore: Add .cosine Dockerfile to bootstrap local dev environment

### DIFF
--- a/.cosine/Dockerfile
+++ b/.cosine/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_VERSION=16.20.2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        g++ \
+        git \
+        make \
+        python3 \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN arch="$(dpkg --print-architecture)" \
+    && case "$arch" in \
+        amd64) node_arch='x64' ;; \
+        arm64) node_arch='arm64' ;; \
+        *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${node_arch}.tar.xz" -o /tmp/node.tar.xz \
+    && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 --no-same-owner \
+    && rm /tmp/node.tar.xz \
+    && node --version \
+    && npm --version
+
+WORKDIR /workspace


### PR DESCRIPTION
- Introduces a reproducible local development environment by adding .cosine/Dockerfile.
- Uses Ubuntu base and installs essential build/runtime tools: ca-certificates, curl, g++, git, make, python3, xz-utils.
- Installs Node.js 16.20.2 for amd64/arm64 from official tarballs and verifies npm/node versions.
- Sets the working directory to /workspace for consistency.
- How to use: docker build -t repo-dev -f .cosine/Dockerfile .; docker run -it --rm -v "$PWD":/workspace repo-dev
- This helps unblock local development and onboarding by providing a single, consistent environment, even though CX infrastructure issues may affect CI/CD.