### PR TITLE
Add local Dockerfile for environment setup and runtime validation

### DIFF
--- a/.cosine/Dockerfile
+++ b/.cosine/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu
+
+ENV DEBIAN_FRONTEND=noninteractive
+ARG NODE_VERSION=16.20.2
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    build-essential \
+    python3 \
+    xz-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN ARCH="$(dpkg --print-architecture)" \
+ && case "$ARCH" in \
+      amd64) NODE_ARCH="x64" ;; \
+      arm64) NODE_ARCH="arm64" ;; \
+      *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
+ && tar -xJf "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+ && rm "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
+ && node --version \
+ && npm --version
+
+WORKDIR /workspace


### PR DESCRIPTION
Adds a reproducible local environment for the repository by introducing .cosine/Dockerfile. The image is based on Ubuntu and installs essential build tools, Python, and curl/npm. It downloads and installs Node.js v16.20.2 for the host architecture (amd64/arm64) and verifies the runtime by printing node and npm versions during the build. The image sets a working directory at /workspace for convenient development and testing. 

How this solves the issue:
- Provides a consistent, reproducible environment to validate the runtime locally.
- Ensures correct Node.js version is installed across architectures.
- Simple workflow to build and run a container that mirrors CI/runtime expectations.

Usage:
- Build: docker build -t cosine-env -f .cosine/Dockerfile .
- Run: docker run --rm -it -v "$PWD":/workspace cosine-env
- Inside container, run node -v and npm -v to verify versions are correct.